### PR TITLE
Fix incorrect file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"grammars": [{
 			"language": "kos",
 			"scopeName": "source.kos",
-			"path": "./syntaxes/kos.tmLanguage"
+			"path": "./syntaxes/kos.tmlanguage"
 		}]
     },
     "scripts": {


### PR DESCRIPTION
I couldn't get the plugin to work on my Linux computer, I found that the problem was an incorrect file path (capitalization). It only affects systems with case-sensitive file systems, after this minor fix everything appears to work correctly.
